### PR TITLE
Migrate to async loading

### DIFF
--- a/Smooth Scrolling/Smooth Scrolling.csproj
+++ b/Smooth Scrolling/Smooth Scrolling.csproj
@@ -28,6 +28,9 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <TargetFrameworkProfile />
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -243,7 +246,7 @@
     <Error Condition="!Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets'))" />
   </Target>
   <Import Project="..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets" Condition="Exists('..\packages\Microsoft.VSSDK.BuildTools.15.1.192\build\Microsoft.VSSDK.BuildTools.targets')" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Smooth Scrolling/SmoothScrollingPackage.cs
+++ b/Smooth Scrolling/SmoothScrollingPackage.cs
@@ -6,8 +6,11 @@
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Threading;
+using Task = System.Threading.Tasks.Task;
 
 namespace SmoothScrolling
 {
@@ -28,48 +31,45 @@ namespace SmoothScrolling
     /// To get loaded into VS, the package must be referred by &lt;Asset Type="Microsoft.VisualStudio.VsPackage" ...&gt; in .vsixmanifest file.
     /// </para>
     /// </remarks>
-    [PackageRegistration(UseManagedResourcesOnly = true)]
+    [PackageRegistration(UseManagedResourcesOnly = true, AllowsBackgroundLoading = true)]
     [InstalledProductRegistration("#110", "#112", "1.0", IconResourceID = 400)] // Info on this package for Help/About
     [Guid(SmoothScrollingPackage.PACKAGE_GUID_STRING)]
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
-    [ProvideAutoLoad(UIContextGuids.NoSolution)]
-    [ProvideOptionPage(typeof(OptionPageGrid),
-    "Smooth Scrolling", "Options", 0, 0, true)]
-    public sealed class SmoothScrollingPackage : Package
+    [ProvideAutoLoad(UIContextGuids.NoSolution, PackageAutoLoadFlags.BackgroundLoad)]
+    [ProvideOptionPage(typeof(OptionPageGrid), "Smooth Scrolling", "Options", 0, 0, true)]
+    public sealed class SmoothScrollingPackage : AsyncPackage
     {
-        public static SmoothScrollingPackage Package { get; private set; }
-
         /// <summary>
         /// SmoothScrollingPackage GUID string.
         /// </summary>
         public const string PACKAGE_GUID_STRING = "2924f2d0-744f-4245-bb67-998bc5662145";
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SmoothScrollingPackage"/> class.
-        /// </summary>
-        public SmoothScrollingPackage()
-        {
-            // Inside this method you can place any initialization code that does not require
-            // any Visual Studio service because at this point the package object is created but
-            // not sited yet inside Visual Studio environment. The place to do all the other
-            // initialization is the Initialize method.
-            Package = this;
-        }
-
         #region Package Members
+
+        private static OptionPageGrid options;
+        private static readonly OptionPageGrid defaultOptions = new OptionPageGrid();
+        public static OptionPageGrid Options
+        {
+            get
+            {
+                if (options == null)
+                {
+                    return defaultOptions;
+                } else {
+                    return options;
+                }
+            }
+        }
 
         /// <summary>
         /// Initialization of the package; this method is called right after the package is sited, so this is the place
         /// where you can put all the initialization code that rely on services provided by VisualStudio.
         /// </summary>
-        protected override void Initialize()
+        protected override async Task InitializeAsync(CancellationToken cancellationToken, IProgress<ServiceProgressData> progress)
         {
-            base.Initialize();
-        }
+            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
-        public OptionPageGrid GetOptions()
-        {
-            return (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
+            options = (OptionPageGrid)GetDialogPage(typeof(OptionPageGrid));
         }
 
         #endregion


### PR DESCRIPTION
You said you have no time to do this, but I guess you are not "against" to migrate to async. Here's my attempt.

Since the options are loaded late, user may start scrolling when it is null. So I decided to just use the default value as stand in. You can change that part to whatever you want.